### PR TITLE
update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-power-grid-model >= 1.6.55
+power-grid-model[doc] >= 1.7
 jupyter
-pandas
 matplotlib


### PR DESCRIPTION
* bump power-grid-model to `v1.7` (required for newton raphson state estimation example from https://github.com/PowerGridModel/power-grid-model/pull/506 )
* Automatically download dependencies for the `power-grid-model` examples (so that they don't go out of date)
