### PR TITLE
Feature/upgrade dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "jupyter>=1.1.1",
     "matplotlib>=3.10.1",
     "pandas>=2.2.3",
-    "power-grid-model[doc]>=1.10.88",
+    "power-grid-model[doc]>=1.12.0",
     "power-grid-model-ds[visualizer]>=1.2.4",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1791,7 +1791,7 @@ requires-dist = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "matplotlib", specifier = ">=3.10.1" },
     { name = "pandas", specifier = ">=2.2.3" },
-    { name = "power-grid-model", extras = ["doc"], specifier = ">=1.10.88" },
+    { name = "power-grid-model", extras = ["doc"], specifier = ">=1.12.0" },
     { name = "power-grid-model-ds", extras = ["visualizer"], specifier = ">=1.2.4" },
 ]
 


### PR DESCRIPTION
Upgrades pgm dependency + uv.lock so that the PGM examples run with recent versions.

Before this PR, running `uv sync` would result in an old version of PGM being installed that is not able to run the Asymmetric Line example. After this PR, that is resolved.