### PR TITLE
Change to release env for syncing examples

### DIFF
--- a/.github/workflows/check-examples-unchanged.yml
+++ b/.github/workflows/check-examples-unchanged.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Contributors to the Power Grid Model project <powergridmodel@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+name: Check examples folder unchanged
+
+on:
+  pull_request:
+    paths:
+      - 'examples/**'
+
+jobs:
+  check-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check if examples folder was modified
+        run: |
+          if git diff --name-only origin/main...HEAD | grep -q '^examples/'; then
+            echo "❌ The examples folder should not be manually modified."
+            echo "PGM Examples are automatically synced from the main power-grid-model repository."
+            exit 1
+          else
+            echo "✅ No changes to examples folder detected."
+          fi

--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -12,14 +12,15 @@ on:
 jobs:
   sync-files:
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
       - name: generate GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.CI_BOT_APP_ID }}
-          private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout PGM workshop repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/sync-examples.yml
+++ b/.github/workflows/sync-examples.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          repositories: power-grid-model-workshop
 
       - name: Checkout PGM workshop repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -36,7 +37,6 @@ jobs:
           path: power-grid-model
           sparse-checkout: docs/examples
           sparse-checkout-cone-mode: false
-          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Move pgm examples to pgm workshop repository
         run: |


### PR DESCRIPTION
- [ ] To confirm if the release bot is set up to have only current repo level access and not access to org level repos. 

I see refresh lock and linter dependencies is missing and needed. Ill add it separately